### PR TITLE
refactor: update zbctl github repository link

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,8 @@ jobs:
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - name: asdf_plugin_test
-        uses: asdf-vm/actions/plugin-test@v1
+      - name: Test asdf-zbctl plugin
+        uses: asdf-vm/actions/plugin-test@1902764435ca0dd2f3388eea723a4f92a4eb8302 # v4
         with:
           command: zbctl version
+          gitref: ${{ github.head_ref || github.ref_name }}

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Use the plugin:
 
 ```shell
 # Show all installable versions
-asdf list-all zbctl
+asdf list all zbctl
 
 # Install specific version
 asdf install zbctl latest

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-GH_REPO="https://github.com/camunda/zeebe"
+GH_REPO="https://github.com/camunda-community-hub/zeebe-client-go"
 TOOL_NAME="zbctl"
 TOOL_TEST="zbctl version"
 


### PR DESCRIPTION
to its new home in the Camunda Community Hub

@aabouzaid I'm confident about the change but I don't know how to test it ;-) Also I'm not sure how to allow older versions to still be downloaded. Maybe we need a switch for the download URL depending on the version number?